### PR TITLE
Fixes to allow shared folders via Guest Additions on OSX El Capitan

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,5 +10,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |vb|
     vb.gui = true
+    vb.customize "pre-boot", [
+      "storageattach", :id,
+      "--storagectl", "SATAController",
+      "--port", "1",
+      "--device", "0",
+      "--type", "dvddrive",
+      "--medium", "/Applications/VirtualBox.app/Contents/MacOS/VBoxGuestAdditions.iso",
+      #"--medium", "emptydrive"
+      ]
   end
 end

--- a/script.sh
+++ b/script.sh
@@ -8,6 +8,13 @@ sudo apt-get update
 sudo apt-get -y install fluxbox xorg unzip vim default-jre rungetty firefox
 
 #=========================================================
+echo "Install guest additions ..."
+#=========================================================
+sudo mkdir /media/cdrom
+sudo mount /dev/cdrom /media/cdrom
+sudo /media/cdrom/VBoxLinuxAdditions.run force
+
+#=========================================================
 echo "Set autologin for the Vagrant user..."
 #=========================================================
 sudo sed -i '$ d' /etc/init/tty1.conf
@@ -91,4 +98,4 @@ echo "ok"
 #=========================================================
 echo "Reboot the VM"
 #=========================================================
-sudo reboot
+sudo shutdown -h now


### PR DESCRIPTION
This is what I had to do to get guest additions (shared folders) to work on Mac.
